### PR TITLE
fix(login): unwrap callbackUrl object and query includes off of href

### DIFF
--- a/src/utils/js/api.js
+++ b/src/utils/js/api.js
@@ -15,7 +15,7 @@ export function isLoginActive() {
 export function startLogin(callbackUrl) {
     let state = '' + Math.random();
 
-    if ( callbackUrl.includes('webpack.js.org') ) {
+    if ( callbackUrl.href.includes('webpack.js.org') ) {
         window.localStorage.githubState = state;
         window.location = 'https://github.com/login/oauth/authorize?client_id=' + GITHUB_CLIENT_ID + '&scope=user:email&state=' + state + '&allow_signup=false&redirect_uri=' + encodeURIComponent(callbackUrl);
 


### PR DESCRIPTION
Fixes #9 

This PR fixes an error encountered in #9 where a user attempts to login using the github button. When pressed there is a user "can't call n.includes of undefined". This is because callbackUrl is an object. I unwrap the object and let the logic run against the href instead. 

