### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/src/utils/js/api.dev.js
+++ b/src/utils/js/api.dev.js
@@ -80,7 +80,7 @@ export function startLogin(callbackUrl) {
 export function continueLogin() {
     if ( /^\?login=/.test(window.location.search) ) {
         return delay(2000).then(() => {
-            setTimeout(() => window.location = decodeURIComponent(window.location.search.substr(7), 100));
+            setTimeout(() => window.location = decodeURIComponent(window.location.search.slice(7), 100));
             return 'developer';
         });
     }

--- a/src/utils/js/api.js
+++ b/src/utils/js/api.js
@@ -34,7 +34,7 @@ export function continueLogin() {
         return login(match[1], match[2]).then(result => {
             setTimeout(() => {
                 let href = window.location.href;
-                window.location = href.substr(0, href.length - window.location.search.length);
+                window.location = href.slice(0, href.length - window.location.search.length);
             }, 100);
 
             return result;


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None

### Additional Info
